### PR TITLE
Update to .NET SDK 8, including all dependencies

### DIFF
--- a/Fizzler.sln
+++ b/Fizzler.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29911.84
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35013.160
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8FC1F69B-FAFC-484C-984B-78FA7E224BCB}"
 	ProjectSection(SolutionItems) = preProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ build_script:
 - ps: |-
     $id = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
     if ($isWindows) { .\pack.cmd ci-$id } else { ./pack.sh ci-$id }
-    dotnet sourcelink test "$(dir dist\*.nupkg)"
+    dotnet sourcelink test "$(dir dist\*.symbols.nupkg)"
 test_script:
 - cmd: test.cmd
 - sh: ./test.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 image:
-- Visual Studio 2019
+- Visual Studio 2022
 - Ubuntu
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ build_script:
 - ps: |-
     $id = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
     if ($isWindows) { .\pack.cmd ci-$id } else { ./pack.sh ci-$id }
-    dotnet sourcelink test "$(dir dist\*.symbols.nupkg)"
+    dotnet sourcelink test "$(dir dist\*.nupkg)"
 test_script:
 - cmd: test.cmd
 - sh: ./test.sh

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.200",
+    "version": "6.0.100-preview.1.21103.13",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.1.21103.13",
+    "version": "8.0.302",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Fizzler.csproj
+++ b/src/Fizzler.csproj
@@ -2,7 +2,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
-    <LangVersion>7</LangVersion>
+    <!--
+      no harm in using latest language version the .NET SDK supports, in this case latest could be c# 9
+      and it also seems that things like switch expressions, or patterns, or even pattern matching does
+      not require anything extra not in the older TargetFrameworks so it should be fine as I use it to
+      unify the codebase to the newer syntax from the newer language versions, despite what the
+      TargetFramework(s) are set to which keeps if preprocessor blocks out of the code.
+      The only exception is when using the syntax for System.Index and System.Range where those
+      TargetFrameworks lack those classes for it (in which case the only way to use it would be to
+      provide your own copy of them based on the code in .NET 5/6).
+    -->
+    <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Fizzler.snk</AssemblyOriginatorKeyFile>
     <VersionPrefix>1.3.0</VersionPrefix>
@@ -16,21 +26,23 @@
     <PackageTags>selectors w3c</PackageTags>
     <PackageIconUrl></PackageIconUrl>
     <PackageOutputPath>..\dist</PackageOutputPath>
-    <IncludeSymbols>true</IncludeSymbols>
-    <IncludeSource>true</IncludeSource>
     <Copyright>Copyright © 2009 Atif Aziz, Colin Ramsay. All rights reserved. Portions Copyright © 2008 Novell, Inc.</Copyright>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <EmbedUntrackedSource>true</EmbedUntrackedSource>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\</OutputPath>
-    <DebugType>full</DebugType>
+    <!-- to embed complete (full) pdbs in Debug builds. -->
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\bin\Release\</OutputPath>
+    <!-- to embed complete pdbs in Release builds as well. -->
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.0'">
@@ -42,6 +54,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- There are prerelease versions of this as well in the .NET 5/6 azure feeds. -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Fizzler.csproj
+++ b/src/Fizzler.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Fizzler.csproj
+++ b/src/Fizzler.csproj
@@ -2,17 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
-    <!--
-      no harm in using latest language version the .NET SDK supports, in this case latest could be c# 9
-      and it also seems that things like switch expressions, or patterns, or even pattern matching does
-      not require anything extra not in the older TargetFrameworks so it should be fine as I use it to
-      unify the codebase to the newer syntax from the newer language versions, despite what the
-      TargetFramework(s) are set to which keeps if preprocessor blocks out of the code.
-      The only exception is when using the syntax for System.Index and System.Range where those
-      TargetFrameworks lack those classes for it (in which case the only way to use it would be to
-      provide your own copy of them based on the code in .NET 5/6).
-    -->
-    <LangVersion>latest</LangVersion>
+    <LangVersion>7</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Fizzler.snk</AssemblyOriginatorKeyFile>
     <VersionPrefix>1.3.0</VersionPrefix>
@@ -26,23 +16,21 @@
     <PackageTags>selectors w3c</PackageTags>
     <PackageIconUrl></PackageIconUrl>
     <PackageOutputPath>..\dist</PackageOutputPath>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
     <Copyright>Copyright © 2009 Atif Aziz, Colin Ramsay. All rights reserved. Portions Copyright © 2008 Novell, Inc.</Copyright>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <EmbedUntrackedSource>true</EmbedUntrackedSource>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\bin\Debug\</OutputPath>
-    <!-- to embed complete (full) pdbs in Debug builds. -->
-    <DebugType>embedded</DebugType>
-    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\bin\Release\</OutputPath>
-    <!-- to embed complete pdbs in Release builds as well. -->
-    <DebugType>embedded</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.0'">
@@ -54,7 +42,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- There are prerelease versions of this as well in the .NET 5/6 azure feeds. -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/tests/Fizzler.Tests.csproj
+++ b/tests/Fizzler.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>7</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.5.0" />

--- a/tests/Fizzler.Tests.csproj
+++ b/tests/Fizzler.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/tests/Fizzler.Tests.csproj
+++ b/tests/Fizzler.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>7</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.5.0" />

--- a/tests/Fizzler.Tests.csproj
+++ b/tests/Fizzler.Tests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.5.0" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="Microsoft.CodeCoverage" Version="17.10.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Fizzler.csproj" />

--- a/tests/HumanReadableSelectorGeneratorTests.cs
+++ b/tests/HumanReadableSelectorGeneratorTests.cs
@@ -23,6 +23,7 @@ namespace Fizzler.Tests
 {
     using System;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class HumanReadableSelectorGeneratorTests

--- a/tests/NamespacePrefixTests.cs
+++ b/tests/NamespacePrefixTests.cs
@@ -22,6 +22,7 @@
 namespace Fizzler.Tests
 {
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class NamespacePrefixTests

--- a/tests/ParserTests.cs
+++ b/tests/ParserTests.cs
@@ -26,6 +26,7 @@ namespace Fizzler.Tests
     using System;
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     #endregion
 

--- a/tests/ReaderTests.cs
+++ b/tests/ReaderTests.cs
@@ -27,6 +27,7 @@ namespace Fizzler.Tests
     using System.Collections;
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     #endregion
 

--- a/tests/SelectorGeneratorTeeTests.cs
+++ b/tests/SelectorGeneratorTeeTests.cs
@@ -28,6 +28,7 @@ namespace Fizzler.Tests
     using System.Linq;
     using System.Reflection;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     #endregion
 

--- a/tests/TokenTests.cs
+++ b/tests/TokenTests.cs
@@ -25,6 +25,7 @@ namespace Fizzler.Tests
 
     using System;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     #endregion
 

--- a/tests/TokenerTests.cs
+++ b/tests/TokenerTests.cs
@@ -27,6 +27,7 @@ namespace Fizzler.Tests
     using System.IO;
     using System.Linq;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     #endregion
 


### PR DESCRIPTION
This PR refreshes the solution to use the latest .NET SDK (8) and versions of dependencies.

---
PS This PR merges changes from PR #85 by @AraHaan
