### PR TITLE
Migrate away from classic NUnit assertions

### DIFF
--- a/tests/HumanReadableSelectorGeneratorTests.cs
+++ b/tests/HumanReadableSelectorGeneratorTests.cs
@@ -23,7 +23,6 @@ namespace Fizzler.Tests
 {
     using System;
     using NUnit.Framework;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class HumanReadableSelectorGeneratorTests
@@ -169,7 +168,7 @@ namespace Fizzler.Tests
         {
             var generator = new HumanReadableSelectorGenerator();
             Parser.Parse(selector, generator);
-            Assert.AreEqual(message, generator.Text);
+            Assert.That(generator.Text, Is.EqualTo(message));
         }
     }
 }

--- a/tests/NamespacePrefixTests.cs
+++ b/tests/NamespacePrefixTests.cs
@@ -22,7 +22,6 @@
 namespace Fizzler.Tests
 {
     using NUnit.Framework;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class NamespacePrefixTests

--- a/tests/ParserTests.cs
+++ b/tests/ParserTests.cs
@@ -26,7 +26,6 @@ namespace Fizzler.Tests
     using System;
     using System.Collections.Generic;
     using NUnit.Framework;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     #endregion
 

--- a/tests/ReaderTests.cs
+++ b/tests/ReaderTests.cs
@@ -27,7 +27,6 @@ namespace Fizzler.Tests
     using System.Collections;
     using System.Collections.Generic;
     using NUnit.Framework;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     #endregion
 
@@ -53,13 +52,13 @@ namespace Fizzler.Tests
         [Test]
         public void HasMoreWhenEmpty()
         {
-            Assert.IsFalse(new Reader<int>(new int[0]).HasMore);
+            Assert.That(new Reader<int>(new int[0]).HasMore, Is.False);
         }
 
         [Test]
         public void HasMoreWhenNotEmpty()
         {
-            Assert.IsTrue(new Reader<int>(new int[1]).HasMore);
+            Assert.That(new Reader<int>(new int[1]).HasMore, Is.True);
         }
 
         [Test]
@@ -76,11 +75,11 @@ namespace Fizzler.Tests
             reader.Unread(56);
             reader.Unread(34);
             reader.Unread(12);
-            Assert.AreEqual(12, reader.Read());
-            Assert.AreEqual(34, reader.Read());
-            Assert.AreEqual(56, reader.Read());
-            Assert.AreEqual(78, reader.Read());
-            Assert.AreEqual(910, reader.Read());
+            Assert.That(reader.Read(), Is.EqualTo(12));
+            Assert.That(reader.Read(), Is.EqualTo(34));
+            Assert.That(reader.Read(), Is.EqualTo(56));
+            Assert.That(reader.Read(), Is.EqualTo(78));
+            Assert.That(reader.Read(), Is.EqualTo(910));
         }
 
         [Test]
@@ -94,68 +93,68 @@ namespace Fizzler.Tests
         public void PeekNonEmpty()
         {
             var reader = new Reader<int>(new[] { 12, 34, 56 });
-            Assert.AreEqual(12, reader.Peek());
-            Assert.AreEqual(12, reader.Read());
-            Assert.AreEqual(34, reader.Peek());
-            Assert.AreEqual(34, reader.Read());
-            Assert.AreEqual(56, reader.Peek());
-            Assert.AreEqual(56, reader.Read());
+            Assert.That(reader.Peek(), Is.EqualTo(12));
+            Assert.That(reader.Read(), Is.EqualTo(12));
+            Assert.That(reader.Peek(), Is.EqualTo(34));
+            Assert.That(reader.Read(), Is.EqualTo(34));
+            Assert.That(reader.Peek(), Is.EqualTo(56));
+            Assert.That(reader.Read(), Is.EqualTo(56));
         }
 
         [Test]
         public void Enumeration()
         {
             var e = new Reader<int>(new[] { 12, 34, 56 }).GetEnumerator();
-            Assert.IsTrue(e.MoveNext());
-            Assert.AreEqual(12, e.Current);
-            Assert.IsTrue(e.MoveNext());
-            Assert.AreEqual(34, e.Current);
-            Assert.IsTrue(e.MoveNext());
-            Assert.AreEqual(56, e.Current);
-            Assert.IsFalse(e.MoveNext());
+            Assert.That(e.MoveNext(), Is.True);
+            Assert.That(e.Current, Is.EqualTo(12));
+            Assert.That(e.MoveNext(), Is.True);
+            Assert.That(e.Current, Is.EqualTo(34));
+            Assert.That(e.MoveNext(), Is.True);
+            Assert.That(e.Current, Is.EqualTo(56));
+            Assert.That(e.MoveNext(), Is.False);
         }
 
         [Test]
         public void EnumerationNonGeneric()
         {
             var e = ((IEnumerable) new Reader<int>(new[] { 12, 34, 56 })).GetEnumerator();
-            Assert.IsTrue(e.MoveNext());
-            Assert.AreEqual(12, e.Current);
-            Assert.IsTrue(e.MoveNext());
-            Assert.AreEqual(34, e.Current);
-            Assert.IsTrue(e.MoveNext());
-            Assert.AreEqual(56, e.Current);
-            Assert.IsFalse(e.MoveNext());
+            Assert.That(e.MoveNext(), Is.True);
+            Assert.That(e.Current, Is.EqualTo(12));
+            Assert.That(e.MoveNext(), Is.True);
+            Assert.That(e.Current, Is.EqualTo(34));
+            Assert.That(e.MoveNext(), Is.True);
+            Assert.That(e.Current, Is.EqualTo(56));
+            Assert.That(e.MoveNext(), Is.False);
         }
 
         [Test]
         public void CloseDisposes()
         {
             var e = new TestEnumerator<object>();
-            Assert.IsFalse(e.Disposed);
+            Assert.That(e.Disposed, Is.False);
             new Reader<object>(e).Close();
-            Assert.IsTrue(e.Disposed);
+            Assert.That(e.Disposed, Is.True);
         }
 
         [Test]
         public void DisposeDisposes()
         {
             var e = new TestEnumerator<object>();
-            Assert.IsFalse(e.Disposed);
+            Assert.That(e.Disposed, Is.False);
             ((IDisposable) new Reader<object>(e)).Dispose();
-            Assert.IsTrue(e.Disposed);
+            Assert.That(e.Disposed, Is.True);
         }
 
         [Test]
         public void DisposeDisposesOnce()
         {
             var e = new TestEnumerator<object>();
-            Assert.IsFalse(e.Disposed);
+            Assert.That(e.Disposed, Is.False);
             var disposable = ((IDisposable)new Reader<object>(e));
             disposable.Dispose();
-            Assert.AreEqual(1, e.DisposeCallCount);
+            Assert.That(e.DisposeCallCount, Is.EqualTo(1));
             disposable.Dispose();
-            Assert.AreEqual(1, e.DisposeCallCount);
+            Assert.That(e.DisposeCallCount, Is.EqualTo(1));
         }
 
         [Test]

--- a/tests/SelectorGeneratorTeeTests.cs
+++ b/tests/SelectorGeneratorTeeTests.cs
@@ -28,7 +28,6 @@ namespace Fizzler.Tests
     using System.Linq;
     using System.Reflection;
     using NUnit.Framework;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     #endregion
 
@@ -241,14 +240,14 @@ namespace Fizzler.Tests
             // both called with the same arguments and in the right order!
 
             var recording = recordings.Dequeue();
-            Assert.AreSame(_primary, recording.Target);
-            Assert.AreEqual(action.Name, MapMethod<ISelectorGenerator>(recording.Method).Name);
-            Assert.AreEqual(args, recording.Arguments);
+            Assert.That(recording.Target, Is.SameAs(_primary));
+            Assert.That(MapMethod<ISelectorGenerator>(recording.Method).Name, Is.EqualTo(action.Name));
+            Assert.That(recording.Arguments, Is.EqualTo(args));
 
             recording = recordings.Dequeue();
-            Assert.AreSame(_secondary, recording.Target);
-            Assert.AreEqual(action.Name, MapMethod<ISelectorGenerator>(recording.Method).Name);
-            Assert.AreEqual(args, recording.Arguments);
+            Assert.That(recording.Target, Is.SameAs(_secondary));
+            Assert.That(MapMethod<ISelectorGenerator>(recording.Method).Name, Is.EqualTo(action.Name));
+            Assert.That(recording.Arguments, Is.EqualTo(args));
         }
 
         static MethodInfo MapMethod<T>(MethodInfo method) where T : class

--- a/tests/TokenTests.cs
+++ b/tests/TokenTests.cs
@@ -25,7 +25,6 @@ namespace Fizzler.Tests
 
     using System;
     using NUnit.Framework;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     #endregion
 
@@ -247,11 +246,11 @@ namespace Fizzler.Tests
 
         static void AssertToken(TokenKind expectedKind, string expectedText, Token token)
         {
-            Assert.AreEqual(expectedKind, token.Kind);
+            Assert.That(token.Kind, Is.EqualTo(expectedKind));
             if (expectedText == null)
-                Assert.IsNull(token.Text);
+                Assert.That(token.Text, Is.Null);
             else
-                Assert.AreEqual(expectedText, token.Text);
+                Assert.That(token.Text, Is.EqualTo(expectedText));
         }
 
         [Test]
@@ -289,30 +288,30 @@ namespace Fizzler.Tests
         [Test]
         public void StringRepresentations()
         {
-            Assert.AreEqual("Eoi", Token.Eoi().ToString());
-            Assert.AreEqual("Ident: foo", Token.Ident("foo").ToString());
-            Assert.AreEqual("Hash: foo", Token.Hash("foo").ToString());
-            Assert.AreEqual("Includes", Token.Includes().ToString());
-            Assert.AreEqual("DashMatch", Token.DashMatch().ToString());
-            Assert.AreEqual("PrefixMatch", Token.PrefixMatch().ToString());
-            Assert.AreEqual("SuffixMatch", Token.SuffixMatch().ToString());
-            Assert.AreEqual("SubstringMatch", Token.SubstringMatch().ToString());
-            Assert.AreEqual("String: foo", Token.String("foo").ToString());
-            Assert.AreEqual("Plus", Token.Plus().ToString());
-            Assert.AreEqual("Greater", Token.Greater().ToString());
-            Assert.AreEqual("WhiteSpace:  ", Token.WhiteSpace(" ").ToString());
-            Assert.AreEqual("Function: foo", Token.Function("foo").ToString());
-            Assert.AreEqual("Integer: 42", Token.Integer("42").ToString());
-            Assert.AreEqual("Tilde", Token.Tilde().ToString());
-            Assert.AreEqual("Char: *", Token.Star().ToString());
-            Assert.AreEqual("Char: .", Token.Dot().ToString());
-            Assert.AreEqual("Char: :", Token.Colon().ToString());
-            Assert.AreEqual("Char: ,", Token.Comma().ToString());
-            Assert.AreEqual("Char: =", Token.Equals().ToString());
-            Assert.AreEqual("Char: [", Token.LeftBracket().ToString());
-            Assert.AreEqual("Char: ]", Token.RightBracket().ToString());
-            Assert.AreEqual("Char: )", Token.RightParenthesis().ToString());
-            Assert.AreEqual("Char: |", Token.Pipe().ToString());
+            Assert.That(Token.Eoi().ToString(), Is.EqualTo("Eoi"));
+            Assert.That(Token.Ident("foo").ToString(), Is.EqualTo("Ident: foo"));
+            Assert.That(Token.Hash("foo").ToString(), Is.EqualTo("Hash: foo"));
+            Assert.That(Token.Includes().ToString(), Is.EqualTo("Includes"));
+            Assert.That(Token.DashMatch().ToString(), Is.EqualTo("DashMatch"));
+            Assert.That(Token.PrefixMatch().ToString(), Is.EqualTo("PrefixMatch"));
+            Assert.That(Token.SuffixMatch().ToString(), Is.EqualTo("SuffixMatch"));
+            Assert.That(Token.SubstringMatch().ToString(), Is.EqualTo("SubstringMatch"));
+            Assert.That(Token.String("foo").ToString(), Is.EqualTo("String: foo"));
+            Assert.That(Token.Plus().ToString(), Is.EqualTo("Plus"));
+            Assert.That(Token.Greater().ToString(), Is.EqualTo("Greater"));
+            Assert.That(Token.WhiteSpace(" ").ToString(), Is.EqualTo("WhiteSpace:  "));
+            Assert.That(Token.Function("foo").ToString(), Is.EqualTo("Function: foo"));
+            Assert.That(Token.Integer("42").ToString(), Is.EqualTo("Integer: 42"));
+            Assert.That(Token.Tilde().ToString(), Is.EqualTo("Tilde"));
+            Assert.That(Token.Star().ToString(), Is.EqualTo("Char: *"));
+            Assert.That(Token.Dot().ToString(), Is.EqualTo("Char: ."));
+            Assert.That(Token.Colon().ToString(), Is.EqualTo("Char: :"));
+            Assert.That(Token.Comma().ToString(), Is.EqualTo("Char: ,"));
+            Assert.That(Token.Equals().ToString(), Is.EqualTo("Char: ="));
+            Assert.That(Token.LeftBracket().ToString(), Is.EqualTo("Char: ["));
+            Assert.That(Token.RightBracket().ToString(), Is.EqualTo("Char: ]"));
+            Assert.That(Token.RightParenthesis().ToString(), Is.EqualTo("Char: )"));
+            Assert.That(Token.Pipe().ToString(), Is.EqualTo("Char: |"));
         }
     }
 }

--- a/tests/TokenerTests.cs
+++ b/tests/TokenerTests.cs
@@ -27,7 +27,6 @@ namespace Fizzler.Tests
     using System.IO;
     using System.Linq;
     using NUnit.Framework;
-    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     #endregion
 
@@ -37,122 +36,122 @@ namespace Fizzler.Tests
         [Test]
         public void NullInput()
         {
-            Assert.AreEqual(Token.Eoi(), Tokener.Tokenize((string) null).Single());
+            Assert.That(Tokener.Tokenize((string) null).Single(), Is.EqualTo(Token.Eoi()));
         }
 
         [Test]
         public void EmptyInput()
         {
-            Assert.AreEqual(Token.Eoi(), Tokener.Tokenize(string.Empty).Single());
+            Assert.That(Tokener.Tokenize(string.Empty).Single(), Is.EqualTo(Token.Eoi()));
         }
 
         [TestCase(" \r \n \f \t ", " \r \n \f \t ")]
         [TestCase(" \r \n \f \t ", " \r \n \f \t etc")]
         public void WhiteSpace(string ws, string input)
         {
-            Assert.AreEqual(Token.WhiteSpace(ws), Tokener.Tokenize(input).First());
+            Assert.That(Tokener.Tokenize(input).First(), Is.EqualTo(Token.WhiteSpace(ws)));
         }
 
         [Test]
         public void Colon()
         {
-            Assert.AreEqual(Token.Colon(), Tokener.Tokenize(":").First());
+            Assert.That(Tokener.Tokenize(":").First(), Is.EqualTo(Token.Colon()));
         }
 
         [Test]
         public void Comma()
         {
-            Assert.AreEqual(Token.Comma(), Tokener.Tokenize(",").First());
+            Assert.That(Tokener.Tokenize(",").First(), Is.EqualTo(Token.Comma()));
         }
 
         [Test]
         public void CommaWhiteSpacePrepended()
         {
-            Assert.AreEqual(Token.Comma(), Tokener.Tokenize("  ,").First());
+            Assert.That(Tokener.Tokenize("  ,").First(), Is.EqualTo(Token.Comma()));
         }
 
         [Test]
         public void Plus()
         {
-            Assert.AreEqual(Token.Plus(), Tokener.Tokenize("+").First());
+            Assert.That(Tokener.Tokenize("+").First(), Is.EqualTo(Token.Plus()));
         }
 
         [Test]
         public void Equals()
         {
-            Assert.AreEqual(Token.Equals(), Tokener.Tokenize("=").First());
+            Assert.That(Tokener.Tokenize("=").First(), Is.EqualTo(Token.Equals()));
         }
 
         [Test]
         public void LeftBracket()
         {
-            Assert.AreEqual(Token.LeftBracket(), Tokener.Tokenize("[").First());
+            Assert.That(Tokener.Tokenize("[").First(), Is.EqualTo(Token.LeftBracket()));
         }
 
         [Test]
         public void RightBracket()
         {
-            Assert.AreEqual(Token.RightBracket(), Tokener.Tokenize("]").First());
+            Assert.That(Tokener.Tokenize("]").First(), Is.EqualTo(Token.RightBracket()));
         }
 
         [Test]
         public void PlusWhiteSpacePrepended()
         {
-            Assert.AreEqual(Token.Plus(), Tokener.Tokenize("  +").First());
+            Assert.That(Tokener.Tokenize("  +").First(), Is.EqualTo(Token.Plus()));
         }
 
         [Test]
         public void RightParenthesis()
         {
-            Assert.AreEqual(Token.RightParenthesis(), Tokener.Tokenize(")").First());
+            Assert.That(Tokener.Tokenize(")").First(), Is.EqualTo(Token.RightParenthesis()));
         }
 
         [Test]
         public void Greater()
         {
-            Assert.AreEqual(Token.Greater(), Tokener.Tokenize(">").First());
+            Assert.That(Tokener.Tokenize(">").First(), Is.EqualTo(Token.Greater()));
         }
 
         [Test]
         public void GreaterWhiteSpacePrepended()
         {
-            Assert.AreEqual(Token.Greater(), Tokener.Tokenize("  >").First());
+            Assert.That(Tokener.Tokenize("  >").First(), Is.EqualTo(Token.Greater()));
         }
 
         [Test]
         public void IdentifierLowerCaseOnly()
         {
-            Assert.AreEqual(Token.Ident("foo"), Tokener.Tokenize("foo").First());
+            Assert.That(Tokener.Tokenize("foo").First(), Is.EqualTo(Token.Ident("foo")));
         }
 
         [Test]
         public void IdentifierMixedCase()
         {
-            Assert.AreEqual(Token.Ident("FoObAr"), Tokener.Tokenize("FoObAr").First());
+            Assert.That(Tokener.Tokenize("FoObAr").First(), Is.EqualTo(Token.Ident("FoObAr")));
         }
 
         [Test]
         public void IdentifierIncludingDigits()
         {
-            Assert.AreEqual(Token.Ident("foobar42"), Tokener.Tokenize("foobar42").First());
+            Assert.That(Tokener.Tokenize("foobar42").First(), Is.EqualTo(Token.Ident("foobar42")));
         }
 
         [Test]
         public void IdentifierWithUnderscores()
         {
-            Assert.AreEqual(Token.Ident("_foo_BAR_42_"), Tokener.Tokenize("_foo_BAR_42_").First());
+            Assert.That(Tokener.Tokenize("_foo_BAR_42_").First(), Is.EqualTo(Token.Ident("_foo_BAR_42_")));
         }
 
         [Test]
         public void IdentifierWithHypens()
         {
-            Assert.AreEqual(Token.Ident("foo-BAR-42"), Tokener.Tokenize("foo-BAR-42").First());
+            Assert.That(Tokener.Tokenize("foo-BAR-42").First(), Is.EqualTo(Token.Ident("foo-BAR-42")));
         }
 
         [Test]
         public void IdentifierUsingVendorExtensionSyntax()
         {
-            Assert.AreEqual(Token.Ident("-foo-BAR-42"), Tokener.Tokenize("-foo-BAR-42").First());
+            Assert.That(Tokener.Tokenize("-foo-BAR-42").First(), Is.EqualTo(Token.Ident("-foo-BAR-42")));
         }
 
         [Test]
@@ -165,85 +164,86 @@ namespace Fizzler.Tests
         [Test]
         public void Hash()
         {
-            Assert.AreEqual(Token.Hash("foo_BAR-baz-42"), Tokener.Tokenize("#foo_BAR-baz-42").First());
+            Assert.That(Tokener.Tokenize("#foo_BAR-baz-42").First(), Is.EqualTo(Token.Hash("foo_BAR-baz-42")));
         }
 
         [Test]
         public void Includes()
         {
-            Assert.AreEqual(TokenKind.Includes, Tokener.Tokenize("~=").First().Kind);
+            Assert.That(Tokener.Tokenize("~=").First().Kind, Is.EqualTo(TokenKind.Includes));
         }
 
         [Test]
         public void TildeTilde()
         {
-            Assert.AreEqual(new[] { Token.Tilde(), Token.Tilde() }, Tokener.Tokenize("~~").Take(2).ToArray());
+            Assert.That(Tokener.Tokenize("~~").Take(2).ToArray(), Is.EqualTo(new[] { Token.Tilde(), Token.Tilde() }));
         }
 
         [Test]
         public void DashMatch()
         {
-            Assert.AreEqual(TokenKind.DashMatch, Tokener.Tokenize("|=").First().Kind);
+            Assert.That(Tokener.Tokenize("|=").First().Kind, Is.EqualTo(TokenKind.DashMatch));
         }
 
         [Test]
         public void Pipe()
         {
-            Assert.AreEqual(new[] { Token.Char('|'), Token.Char('|') }, Tokener.Tokenize("||").Take(2).ToArray());
+            Assert.That(Tokener.Tokenize("||").Take(2).ToArray(),
+                        Is.EqualTo(new[] { Token.Char('|'), Token.Char('|') }));
         }
 
         [TestCase("\"\"")]
         [TestCase("''")]
         public void EmptyString(string input)
         {
-            Assert.AreEqual(Token.String(string.Empty), Tokener.Tokenize(input).First());
+            Assert.That(Tokener.Tokenize(input).First(), Is.EqualTo(Token.String(string.Empty)));
         }
 
         [Test]
         public void StringSingleQuoted()
         {
-            Assert.AreEqual(Token.String("foo bar"), Tokener.Tokenize("'foo bar'").First());
+            Assert.That(Tokener.Tokenize("'foo bar'").First(), Is.EqualTo(Token.String("foo bar")));
         }
 
         [Test]
         public void StringDoubleQuoted()
         {
-            Assert.AreEqual(Token.String("foo bar"), Tokener.Tokenize("\"foo bar\"").First());
+            Assert.That(Tokener.Tokenize("\"foo bar\"").First(), Is.EqualTo(Token.String("foo bar")));
         }
 
         [Test]
         public void StringDoubleQuotedWithEscapedDoubleQuotes()
         {
-            Assert.AreEqual(Token.String("foo \"bar\" baz"), Tokener.Tokenize("\"foo \\\"bar\\\" baz\"").First());
+            Assert.That(Tokener.Tokenize("\"foo \\\"bar\\\" baz\"").First(), Is.EqualTo(Token.String("foo \"bar\" baz")));
         }
 
         [Test]
         public void StringSingleQuotedWithEscapedSingleQuotes()
         {
-            Assert.AreEqual(Token.String("foo 'bar' baz"), Tokener.Tokenize(@"'foo \'bar\' baz'").First());
+            Assert.That(Tokener.Tokenize(@"'foo \'bar\' baz'").First(), Is.EqualTo(Token.String("foo 'bar' baz")));
         }
 
         [Test]
         public void StringDoubleQuotedWithEscapedBackslashes()
         {
-            Assert.AreEqual(Token.String(@"foo \bar\ baz"), Tokener.Tokenize("\"foo \\\\bar\\\\ baz\"").First());
+            Assert.That(Tokener.Tokenize("\"foo \\\\bar\\\\ baz\"").First(), Is.EqualTo(Token.String(@"foo \bar\ baz")));
         }
 
         [Test]
         public void StringSingleQuotedWithEscapedBackslashes()
         {
-            Assert.AreEqual(Token.String(@"foo \bar\ baz"), Tokener.Tokenize(@"'foo \\bar\\ baz'").First());
+            Assert.That(Tokener.Tokenize(@"'foo \\bar\\ baz'").First(), Is.EqualTo(Token.String(@"foo \bar\ baz")));
         }
 
         [Test]
         public void BracketedIdent()
         {
             var token = Tokener.Tokenize("[foo]").GetEnumerator();
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.LeftBracket(), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.Ident("foo"), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.RightBracket(), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.Eoi(), token.Current);
-            Assert.IsFalse(token.MoveNext());
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.LeftBracket()));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.Ident("foo")));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.RightBracket()));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.Eoi()));
+            Assert.That(token.MoveNext(), Is.False);
         }
 
         [Test]
@@ -257,74 +257,75 @@ namespace Fizzler.Tests
         public void HashDelimitedCorrectly()
         {
             var token = Tokener.Tokenize("#foo.").GetEnumerator();
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.Hash("foo"), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.Dot(), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.Eoi(), token.Current);
-            Assert.IsFalse(token.MoveNext());
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.Hash("foo")));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.Dot()));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.Eoi()));
+            Assert.That(token.MoveNext(), Is.False);
         }
 
         [Test]
         public void Function()
         {
-            Assert.AreEqual(Token.Function("funky"), Tokener.Tokenize("funky(").First());
+            Assert.That(Tokener.Tokenize("funky(").First(), Is.EqualTo(Token.Function("funky")));
         }
 
         [Test]
         public void FunctionWithEnclosedIdent()
         {
             var token = Tokener.Tokenize("foo(bar)").GetEnumerator();
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.Function("foo"), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.Ident("bar"), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.RightParenthesis(), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.Eoi(), token.Current);
-            Assert.IsFalse(token.MoveNext());
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.Function("foo")));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.Ident("bar")));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.RightParenthesis()));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.Eoi()));
+            Assert.That(token.MoveNext(), Is.False);
         }
 
         [Test]
         public void Integer()
         {
-            Assert.AreEqual(Token.Integer("42"), Tokener.Tokenize("42").First());
+            Assert.That(Tokener.Tokenize("42").First(), Is.EqualTo(Token.Integer("42")));
         }
 
         [Test]
         public void IntegerEnclosed()
         {
             var token = Tokener.Tokenize("[42]").GetEnumerator();
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.LeftBracket(), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.Integer("42"), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.RightBracket(), token.Current);
-            Assert.IsTrue(token.MoveNext()); Assert.AreEqual(Token.Eoi(), token.Current);
-            Assert.IsFalse(token.MoveNext());
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.LeftBracket()));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.Integer("42")));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.RightBracket()));
+            Assert.That(token.MoveNext(), Is.True); Assert.That(token.Current, Is.EqualTo(Token.Eoi()));
+            Assert.That(token.MoveNext(), Is.False);
         }
 
         [Test]
         public void SubstringMatch()
         {
-            Assert.AreEqual(TokenKind.SubstringMatch, Tokener.Tokenize("*=").First().Kind);
+            Assert.That(Tokener.Tokenize("*=").First().Kind, Is.EqualTo(TokenKind.SubstringMatch));
         }
 
         [Test]
         public void Star()
         {
-            Assert.AreEqual(Token.Char('*'), Tokener.Tokenize("*").First());
+            Assert.That(Tokener.Tokenize("*").First(), Is.EqualTo(Token.Char('*')));
         }
 
         [Test]
         public void StarStar()
         {
-            Assert.AreEqual(new[] { Token.Char('*'), Token.Char('*') }, Tokener.Tokenize("**").Take(2).ToArray());
+            Assert.That(Tokener.Tokenize("**").Take(2).ToArray(),
+                        Is.EqualTo(new[] { Token.Char('*'), Token.Char('*') }));
         }
 
         [Test]
         public void Tilde()
         {
-            Assert.AreEqual(TokenKind.Tilde, Tokener.Tokenize("~").First().Kind);
+            Assert.That(Tokener.Tokenize("~").First().Kind, Is.EqualTo(TokenKind.Tilde));
         }
 
         [Test]
         public void TildeWhitespacePrepended()
         {
-            Assert.AreEqual(TokenKind.Tilde, Tokener.Tokenize("  ~").First().Kind);
+            Assert.That(Tokener.Tokenize("  ~").First().Kind, Is.EqualTo(TokenKind.Tilde));
         }
 
         [Test]
@@ -360,8 +361,8 @@ namespace Fizzler.Tests
         [Test]
         public void StringReader()
         {
-            Assert.AreEqual(new[] { Token.Integer("123"), Token.Comma(), Token.Char('*'), Token.Eoi() },
-                Tokener.Tokenize(new StringReader("123,*")).ToArray());
+            Assert.That(Tokener.Tokenize(new StringReader("123,*")).ToArray(),
+                        Is.EqualTo(new[] { Token.Integer("123"), Token.Comma(), Token.Char('*'), Token.Eoi() }));
         }
 
         [Test]
@@ -374,14 +375,14 @@ namespace Fizzler.Tests
         [Test]
         public void Not()
         {
-            Assert.AreEqual(Token.Not(), Tokener.Tokenize(":not(").First());
+            Assert.That(Tokener.Tokenize(":not(").First(), Is.EqualTo(Token.Not()));
         }
 
         [Test]
         public void NotNotFunction()
         {
-            Assert.AreEqual(new[] { Token.Char(':'), Token.Function("notnot") },
-                            Tokener.Tokenize(":notnot(").Take(2));
+            Assert.That(Tokener.Tokenize(":notnot(").Take(2),
+                        Is.EqualTo(new[] { Token.Char(':'), Token.Function("notnot") }));
         }
     }
 }


### PR DESCRIPTION
In PR #85, [classic assertions](https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html#classic-assert-migration) were used to allow upgrading to NUnit 4.0. This PR migrates away from classic assertions to use the supported to constraint model.
