### PR TITLE
Enforce & address code & style analysis

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,34 +23,99 @@ indent_size = 4
 max_line_length = 100
 
 [*.cs]
+dotnet_analyzer_diagnostic.category-Style.severity = warning
+
+# IDE0022: Use expression/block body for methods
+dotnet_diagnostic.IDE0022.severity = suggestion
+
+# IDE1006: Naming rule violation
+dotnet_diagnostic.IDE1006.severity = warning
+
+# Naming capitalization styles
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Naming rule that private instance fields must use camel case
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_rule.camel_case_private_fields.severity = warning
+dotnet_naming_rule.camel_case_private_fields.symbols = private_fields
+dotnet_naming_rule.camel_case_private_fields.style = camel_case_style
+
+# Naming rule that static read-only fields must use Pascal case
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = *
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = readonly, static
+dotnet_naming_rule.pascal_case_static_readonly_fields.severity = warning
+dotnet_naming_rule.pascal_case_static_readonly_fields.symbols = static_readonly_fields
+dotnet_naming_rule.pascal_case_static_readonly_fields.style = pascal_case_style
+
+# Naming rule that const fields must use Pascal case
+dotnet_naming_symbols.const_fields.applicable_kinds = field
+dotnet_naming_symbols.const_fields.applicable_accessibilities = *
+dotnet_naming_symbols.const_fields.required_modifiers = const
+dotnet_naming_rule.pascal_case_const_fields.severity = warning
+dotnet_naming_rule.pascal_case_const_fields.symbols = const_fields
+dotnet_naming_rule.pascal_case_const_fields.style = pascal_case_style
+
+# this. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
 # Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true
+csharp_style_var_when_type_is_apparent = true
+csharp_style_var_elsewhere = true
 
 # Prefer method-like constructs to have a block body
-csharp_style_expression_bodied_methods = false:none
-csharp_style_expression_bodied_constructors = false:none
-csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_methods = true
+csharp_style_expression_bodied_constructors = true
+csharp_style_expression_bodied_operators = true
 
 # Prefer property-like constructs to have an expression-body
-csharp_style_expression_bodied_properties = true:none
-csharp_style_expression_bodied_indexers = true:none
-csharp_style_expression_bodied_accessors = true:none
+csharp_style_expression_bodied_properties = true
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_accessors = true
 
 # Suggest more modern language features when available
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_throw_expression = true
+csharp_style_conditional_delegate_call = true
+csharp_prefer_simple_default_expression = true
 
 # Spacing
-csharp_space_after_cast = true
+csharp_space_after_cast = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_between_method_declaration_parameter_list_parentheses = false
 
 # Wrapping
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
+
+# Indentation
+csharp_indent_case_contents_when_block = false
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = omit_if_default
+
+# IDE0011: Add braces
+csharp_prefer_braces = when_multiline
+
+# IDE0061: Use block body for local functions
+csharp_style_expression_bodied_local_functions = true
+
+# IDE0065: Misplaced using directive
+csharp_using_directive_placement = inside_namespace
+
+# IDE0048: Add parentheses for clarity
+dotnet_diagnostic.IDE0048.severity = suggestion
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = suggestion
+
+# IDE0046: Convert to conditional expression
+dotnet_diagnostic.IDE0046.severity = suggestion

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,9 @@
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>8.0-all</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <!-- Workaround for IDE0005 (Remove unnecessary usings/imports); see https://github.com/dotnet/roslyn/issues/41640 -->
+    <NoWarn>EnableGenerateDocumentationFile</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Either.cs
+++ b/src/Either.cs
@@ -47,70 +47,66 @@ namespace Fizzler
         public abstract TResult Fold<TResult>(Func<TA, TResult> a, Func<TB, TResult> b);
         public abstract TResult Fold<T, TResult>(T arg, Func<T, TA, TResult> a, Func<T, TB, TResult> b);
 
-        sealed class AImpl : Either<TA, TB>
+        sealed class AImpl(TA value) : Either<TA, TB>
         {
-            readonly TA _value;
-
-            public AImpl(TA value) => _value = value;
+            readonly TA value = value;
 
             public override int GetHashCode() =>
-                EqualityComparer<TA>.Default.GetHashCode(_value);
+                EqualityComparer<TA>.Default.GetHashCode(this.value);
 
             public override bool Equals(object? obj) => Equals(obj as AImpl);
 
             public override bool Equals(Either<TA, TB>? obj) =>
                 obj is AImpl a
-                && EqualityComparer<TA>.Default.Equals(_value, a._value);
+                && EqualityComparer<TA>.Default.Equals(this.value, a.value);
 
             public override TResult Fold<TResult>(Func<TA, TResult> a, Func<TB, TResult> b)
             {
                 if (a == null) throw new ArgumentNullException(nameof(a));
                 if (b == null) throw new ArgumentNullException(nameof(b));
-                return a(_value);
+                return a(this.value);
             }
 
             public override TResult Fold<T, TResult>(T arg, Func<T, TA, TResult> a, Func<T, TB, TResult> b)
             {
                 if (a == null) throw new ArgumentNullException(nameof(a));
                 if (b == null) throw new ArgumentNullException(nameof(b));
-                return a(arg, _value);
+                return a(arg, this.value);
             }
 
             public override string ToString() =>
-                _value?.ToString() ?? string.Empty;
+                this.value?.ToString() ?? string.Empty;
         }
 
-        sealed class BImpl : Either<TA, TB>
+        sealed class BImpl(TB value) : Either<TA, TB>
         {
-            readonly TB _value;
-
-            public BImpl(TB value) => _value = value;
+            readonly TB value = value;
 
             public override int GetHashCode() =>
-                EqualityComparer<TB>.Default.GetHashCode(_value);
+                EqualityComparer<TB>.Default.GetHashCode(this.value);
 
             public override bool Equals(object? obj) => Equals(obj as BImpl);
 
             public override bool Equals(Either<TA, TB>? obj) =>
                 obj is BImpl b
-                && EqualityComparer<TB>.Default.Equals(_value, b._value);
+                && EqualityComparer<TB>.Default.Equals(this.value, b.value);
 
             public override TResult Fold<TResult>(Func<TA, TResult> a, Func<TB, TResult> b)
             {
                 if (a == null) throw new ArgumentNullException(nameof(a));
                 if (b == null) throw new ArgumentNullException(nameof(b));
-                return b(_value);
+                return b(this.value);
             }
 
             public override TResult Fold<T, TResult>(T arg, Func<T, TA, TResult> a, Func<T, TB, TResult> b)
             {
                 if (a == null) throw new ArgumentNullException(nameof(a));
                 if (b == null) throw new ArgumentNullException(nameof(b));
-                return b(arg, _value);
+                return b(arg, this.value);
             }
 
             public override string ToString() =>
-                _value?.ToString() ?? string.Empty;
+                this.value?.ToString() ?? string.Empty;
         }
     }
 }

--- a/src/HumanReadableSelectorGenerator.cs
+++ b/src/HumanReadableSelectorGenerator.cs
@@ -29,28 +29,28 @@ namespace Fizzler
     /// </summary>
     public class HumanReadableSelectorGenerator : ISelectorGenerator
     {
-        int _chainCount;
-        string? _text;
+        int chainCount;
+        string? text;
 
         /// <summary>
         /// Initializes the text.
         /// </summary>
-        public virtual void OnInit() => _text = null;
+        public virtual void OnInit() => this.text = null;
 
         /// <summary>
         /// Gets the generated human-readable description text.
         /// </summary>
-        public string Text => _text ?? throw new InvalidOperationException();
+        public string Text => this.text ?? throw new InvalidOperationException();
 
         /// <summary>
         /// Generates human-readable for a selector in a group.
         /// </summary>
         public virtual void OnSelector()
         {
-            if (string.IsNullOrEmpty(_text))
-                _text = "Take all";
+            if (string.IsNullOrEmpty(this.text))
+                this.text = "Take all";
             else
-                _text += " and select them. Combined with previous, take all";
+                this.text += " and select them. Combined with previous, take all";
         }
 
         /// <summary>
@@ -58,22 +58,24 @@ namespace Fizzler
         /// </summary>
         public virtual void OnClose()
         {
-            if (_text is not { } text)
+            if (this.text is not { } someText)
                 throw new InvalidOperationException();
 
-            _text = $"{text.Trim()} and select them.";
+            this.text = $"{someText.Trim()} and select them.";
         }
 
         /// <summary>
         /// Adds to the generated human-readable text.
         /// </summary>
         protected void Add(string selector) =>
-            _text += selector ?? throw new ArgumentNullException(nameof(selector));
+            this.text += selector ?? throw new ArgumentNullException(nameof(selector));
 
         /// <summary>
         /// Generates human-readable text of this type selector.
         /// </summary>
+#pragma warning disable CA1725 // Parameter names should match base declaration (compatibility)
         public void Type(NamespacePrefix prefix, string type) =>
+#pragma warning restore CA1725 // Parameter names should match base declaration
             Add($" <{type}> elements");
 
         /// <summary>
@@ -177,14 +179,14 @@ namespace Fizzler
         /// </summary>
         public void Descendant()
         {
-            if (_chainCount > 0)
+            if (this.chainCount > 0)
             {
                 Add(". With those, take only their descendants which are");
             }
             else
             {
                 Add(", then take their descendants which are");
-                _chainCount++;
+                this.chainCount++;
             }
         }
 

--- a/src/IElementOps.cs
+++ b/src/IElementOps.cs
@@ -56,7 +56,9 @@ namespace Fizzler
         /// which is an alternative <see cref="AttributeIncludes"/> when
         /// representing the <c>class</c> attribute.
         /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by-design)
         Selector<TElement> Class(string clazz);
+#pragma warning restore CA1716 // Identifiers should not match keywords
 
         //
         // Attribute selectors

--- a/src/ISelectorGenerator.cs
+++ b/src/ISelectorGenerator.cs
@@ -72,7 +72,9 @@ namespace Fizzler
         /// which is an alternative <see cref="AttributeIncludes"/> when
         /// representing the <c>class</c> attribute.
         /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by-design)
         void Class(string clazz);
+#pragma warning restore CA1716 // Identifiers should not match keywords
 
         //
         // Attribute selectors

--- a/src/NamespacePrefix.cs
+++ b/src/NamespacePrefix.cs
@@ -28,24 +28,24 @@ namespace Fizzler
     /// Represent a type or attribute name.
     /// </summary>
     [Serializable]
-    public struct NamespacePrefix
+    public readonly struct NamespacePrefix : IEquatable<NamespacePrefix>
     {
         /// <summary>
         /// Represents a name from either the default or any namespace
         /// in a target document, depending on whether a default namespace is
         /// in effect or not.
         /// </summary>
-        public static readonly NamespacePrefix None = new NamespacePrefix(null);
+        public static readonly NamespacePrefix None = new(null);
 
         /// <summary>
         /// Represents an empty namespace.
         /// </summary>
-        public static readonly NamespacePrefix Empty = new NamespacePrefix(string.Empty);
+        public static readonly NamespacePrefix Empty = new(string.Empty);
 
         /// <summary>
         /// Represents any namespace.
         /// </summary>
-        public static readonly NamespacePrefix Any = new NamespacePrefix("*");
+        public static readonly NamespacePrefix Any = new("*");
 
         /// <summary>
         /// Initializes an instance with a namespace prefix specification.
@@ -115,5 +115,19 @@ namespace Fizzler
 
             return Text + (IsNone ? null : "|") + name;
         }
+
+        // Equality operators
+
+        /// <summary>
+        /// Indicates whether two namespace prefixes are equal.
+        /// </summary>
+        public static bool operator ==(NamespacePrefix left, NamespacePrefix right) =>
+            left.Equals(right);
+
+        /// <summary>
+        /// Indicates whether two namespace prefixes are inequal.
+        /// </summary>
+        public static bool operator !=(NamespacePrefix left, NamespacePrefix right) =>
+            !left.Equals(right);
     }
 }

--- a/src/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
 Fizzler.HumanReadableSelectorGenerator.Class(string! clazz) -> void
+static Fizzler.NamespacePrefix.operator !=(Fizzler.NamespacePrefix left, Fizzler.NamespacePrefix right) -> bool
+static Fizzler.NamespacePrefix.operator ==(Fizzler.NamespacePrefix left, Fizzler.NamespacePrefix right) -> bool

--- a/src/Reader.cs
+++ b/src/Reader.cs
@@ -35,8 +35,8 @@ namespace Fizzler
     /// </summary>
     public sealed class Reader<T> : IDisposable, IEnumerable<T>
     {
-        IEnumerator<T>? _enumerator;
-        Stack<T>? _buffer;
+        IEnumerator<T>? enumerator;
+        Stack<T>? buffer;
 
         /// <summary>
         /// Initialize a new <see cref="Reader{T}"/> with a base
@@ -51,8 +51,8 @@ namespace Fizzler
         /// </summary>
         public Reader(IEnumerator<T> e)
         {
-            _enumerator = e ?? throw new ArgumentNullException(nameof(e));
-            _buffer = new Stack<T>();
+            this.enumerator = e ?? throw new ArgumentNullException(nameof(e));
+            this.buffer = new Stack<T>();
             RealRead();
         }
 
@@ -61,7 +61,7 @@ namespace Fizzler
         /// <summary>
         /// Indicates whether there is, at least, one value waiting to be read or not.
         /// </summary>
-        public bool HasMore => _buffer is { Count: var count }
+        public bool HasMore => this.buffer is { Count: var count }
                              ? count > 0
                              : throw ObjectDisposedException();
 
@@ -70,9 +70,9 @@ namespace Fizzler
         /// </summary>
         public void Unread(T value)
         {
-            if (_buffer is not { } buffer)
+            if (this.buffer is not { } someBuffer)
                 throw ObjectDisposedException();
-            buffer.Push(value);
+            someBuffer.Push(value);
         }
 
         /// <summary>
@@ -80,15 +80,15 @@ namespace Fizzler
         /// </summary>
         public T Read()
         {
-            switch (_buffer)
+            switch (this.buffer)
             {
                 case null:
                     throw ObjectDisposedException();
                 case { Count: 0 }:
                     throw new InvalidOperationException();
-                case var buffer:
-                    var value = buffer.Pop();
-                    if (buffer.Count == 0)
+                case var someBuffer:
+                    var value = someBuffer.Pop();
+                    if (someBuffer.Count == 0)
                         RealRead();
                     return value;
             }
@@ -100,7 +100,7 @@ namespace Fizzler
         /// <exception cref="InvalidOperationException">
         /// Thrown if there is no value waiting to be read.
         /// </exception>
-        public T Peek() => _buffer switch
+        public T Peek() => this.buffer switch
         {
             null => throw ObjectDisposedException(),
             { Count: 0 } => throw new InvalidOperationException(),
@@ -115,7 +115,7 @@ namespace Fizzler
         /// </summary>
         public IEnumerator<T> GetEnumerator()
         {
-            return _enumerator is not null ? Iterator(this) : throw ObjectDisposedException();
+            return this.enumerator is not null ? Iterator(this) : throw ObjectDisposedException();
 
             static IEnumerator<T> Iterator(Reader<T> reader)
             {
@@ -126,11 +126,11 @@ namespace Fizzler
 
         void RealRead()
         {
-            if (_enumerator is not { } enumerator)
+            if (this.enumerator is not { } someEnumerator)
                 throw ObjectDisposedException();
 
-            if (enumerator.MoveNext())
-                Unread(enumerator.Current);
+            if (someEnumerator.MoveNext())
+                Unread(someEnumerator.Current);
         }
 
         /// <summary>
@@ -139,15 +139,17 @@ namespace Fizzler
         /// </summary>
         public void Close() => Dispose();
 
+#pragma warning disable CA1063 // Implement IDisposable correctly (false negative)
         void IDisposable.Dispose() => Dispose();
+#pragma warning restore CA1063 // Implement IDisposable correctly
 
         void Dispose()
         {
-            if(_enumerator == null)
+            if(this.enumerator == null)
                 return;
-            _enumerator.Dispose();
-            _enumerator = null;
-            _buffer = null;
+            this.enumerator.Dispose();
+            this.enumerator = null;
+            this.buffer = null;
         }
     }
 }

--- a/src/SelectorGenerator.cs
+++ b/src/SelectorGenerator.cs
@@ -34,10 +34,10 @@ namespace Fizzler
     /// </summary>
     public class SelectorGenerator<TElement> : INegationSelectorGenerator
     {
-        readonly IEqualityComparer<TElement> _equalityComparer;
-        Selector<TElement>? _selector;
-        readonly Stack<Selector<TElement>> _selectors;
-        Selector<TElement>? _negationSourceSelector;
+        readonly IEqualityComparer<TElement> equalityComparer;
+        Selector<TElement>? selector;
+        readonly Stack<Selector<TElement>> selectors = new();
+        Selector<TElement>? negationSourceSelector;
 
         /// <summary>
         /// Initializes a new instance of this object with an instance
@@ -51,11 +51,12 @@ namespace Fizzler
         /// of <see cref="IElementOps{TElement}"/> and an equality comparer
         /// used for determining if two elements are equal.
         /// </summary>
+#pragma warning disable IDE0290 // Use primary constructor (preserve doc)
         public SelectorGenerator(IElementOps<TElement> ops, IEqualityComparer<TElement>? equalityComparer)
+#pragma warning restore IDE0290 // Use primary constructor
         {
             Ops = ops ?? throw new ArgumentNullException(nameof(ops));
-            _equalityComparer = equalityComparer ?? EqualityComparer<TElement>.Default;
-            _selectors = new Stack<Selector<TElement>>();
+            this.equalityComparer = equalityComparer ?? EqualityComparer<TElement>.Default;
         }
 
         /// <summary>
@@ -65,7 +66,7 @@ namespace Fizzler
         /// If the generation is not complete, this property returns the
         /// last generated selector.
         /// </remarks>
-        public Selector<TElement> Selector => _selector ?? throw new InvalidOperationException();
+        public Selector<TElement> Selector => this.selector ?? throw new InvalidOperationException();
 
         /// <summary>
         /// Gets the <see cref="IElementOps{TElement}"/> instance that this object
@@ -83,8 +84,8 @@ namespace Fizzler
         /// </remarks>
         public IEnumerable<Selector<TElement>> GetSelectors()
         {
-            var selectors = _selectors;
-            return _selector is { } top
+            var selectors = this.selectors;
+            return this.selector is { } top
                  ? selectors.Concat(Enumerable.Repeat(top, 1))
                  : selectors.Select(s => s);
         }
@@ -96,7 +97,7 @@ namespace Fizzler
         {
             if(selector == null) throw new ArgumentNullException(nameof(selector));
 
-            _selector = _selector is { } top ? (elements => selector(top(elements))) : selector;
+            this.selector = this.selector is { } top ? (elements => selector(top(elements))) : selector;
         }
 
         /// <summary>
@@ -104,8 +105,8 @@ namespace Fizzler
         /// </summary>
         public virtual void OnInit()
         {
-            _selectors.Clear();
-            _selector = null;
+            this.selectors.Clear();
+            this.selector = null;
         }
 
         /// <summary>
@@ -113,9 +114,9 @@ namespace Fizzler
         /// </summary>
         public virtual void OnSelector()
         {
-            if (_selector is { } someSelector)
-                _selectors.Push(someSelector);
-            _selector = null;
+            if (this.selector is { } someSelector)
+                this.selectors.Push(someSelector);
+            this.selector = null;
         }
 
         /// <summary>
@@ -123,10 +124,10 @@ namespace Fizzler
         /// </summary>
         public virtual void OnClose()
         {
-            var sum = GetSelectors().Aggregate((a, b) => (elements => a(elements).Concat(b(elements))));
+            var sum = GetSelectors().Aggregate((a, b) => elements => a(elements).Concat(b(elements)));
             var normalize = Ops.Descendant();
-            _selector = elements => sum(normalize(elements)).Distinct(_equalityComparer);
-            _selectors.Clear();
+            this.selector = elements => sum(normalize(elements)).Distinct(this.equalityComparer);
+            this.selectors.Clear();
         }
 
         /// <summary>
@@ -142,15 +143,19 @@ namespace Fizzler
         /// which is an alternative <see cref="ISelectorGenerator.AttributeIncludes"/> when
         /// representing the <c>class</c> attribute.
         /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (inherited)
         public virtual void Class(string clazz) =>
             Add(Ops.Class(clazz));
+#pragma warning restore CA1716 // Identifiers should not match keywords
 
         /// <summary>
         /// Generates a <a href="http://www.w3.org/TR/css3-selectors/#type-selectors">type selector</a>,
         /// which represents an instance of the element type in the document tree.
         /// </summary>
+#pragma warning disable CA1725 // Parameter names should match base declaration (compatibility)
         public virtual void Type(NamespacePrefix prefix, string type) =>
             Add(Ops.Type(prefix, type));
+#pragma warning restore CA1725 // Parameter names should match base declaration
 
         /// <summary>
         /// Generates a <a href="http://www.w3.org/TR/css3-selectors/#universal-selector">universal selector</a>,
@@ -301,8 +306,8 @@ namespace Fizzler
         /// </summary>
         public void BeginNegation()
         {
-            _negationSourceSelector = Selector;
-            _selector = null;
+            this.negationSourceSelector = Selector;
+            this.selector = null;
         }
 
         /// <summary>
@@ -311,10 +316,10 @@ namespace Fizzler
         /// </summary>
         public void EndNegation()
         {
-            var negationSourceSelector = _negationSourceSelector ?? throw new InvalidOperationException();
+            var negationSourceSelector = this.negationSourceSelector ?? throw new InvalidOperationException();
             var selector = Selector;
-            _selector = nodes => negationSourceSelector(nodes).Except(selector(nodes), _equalityComparer);
-            _negationSourceSelector = null;
+            this.selector = nodes => negationSourceSelector(nodes).Except(selector(nodes), this.equalityComparer);
+            this.negationSourceSelector = null;
         }
     }
 }

--- a/src/SelectorGeneratorTee.cs
+++ b/src/SelectorGeneratorTee.cs
@@ -45,7 +45,9 @@ namespace Fizzler
         /// with the two other <see cref="ISelectorGenerator"/> objects
         /// it delegates to.
         /// </summary>
+#pragma warning disable IDE0290 // Use primary constructor (preserve doc)
         public SelectorGeneratorTee(ISelectorGenerator primary, ISelectorGenerator secondary)
+#pragma warning restore IDE0290 // Use primary constructor
         {
             Primary = primary ?? throw new ArgumentNullException(nameof(primary));
             Secondary = secondary ?? throw new ArgumentNullException(nameof(secondary));
@@ -81,7 +83,9 @@ namespace Fizzler
         /// <summary>
         /// Delegates to <see cref="Primary"/> then <see cref="Secondary"/> generator.
         /// </summary>
+#pragma warning disable CA1725 // Parameter names should match base declaration (compatibility)
         public void Type(NamespacePrefix prefix, string type)
+#pragma warning restore CA1725 // Parameter names should match base declaration
         {
             Primary.Type(prefix, type);
             Secondary.Type(prefix, type);

--- a/src/Token.cs
+++ b/src/Token.cs
@@ -26,7 +26,7 @@ namespace Fizzler
     /// <summary>
     /// Represent a token and optionally any text associated with it.
     /// </summary>
-    public struct Token : IEquatable<Token>
+    public readonly struct Token : IEquatable<Token>
     {
         /// <summary>
         /// Gets the kind/type/class of the token.
@@ -49,8 +49,7 @@ namespace Fizzler
         /// <summary>
         /// Creates an end-of-input token.
         /// </summary>
-        public static Token Eoi() =>
-            new Token(TokenKind.Eoi);
+        public static Token Eoi() => new(TokenKind.Eoi);
 
         static readonly Token StarToken = Char('*');
         static readonly Token DotToken = Char('.');
@@ -110,42 +109,42 @@ namespace Fizzler
         /// <summary>
         /// Creates a plus token.
         /// </summary>
-        public static Token Plus() => new Token(TokenKind.Plus);
+        public static Token Plus() => new(TokenKind.Plus);
 
         /// <summary>
         /// Creates a greater token.
         /// </summary>
-        public static Token Greater() => new Token(TokenKind.Greater);
+        public static Token Greater() => new(TokenKind.Greater);
 
         /// <summary>
         /// Creates an includes token.
         /// </summary>
-        public static Token Includes() => new Token(TokenKind.Includes);
+        public static Token Includes() => new(TokenKind.Includes);
 
         /// <summary>
         /// Creates a dash-match token.
         /// </summary>
-        public static Token DashMatch() => new Token(TokenKind.DashMatch);
+        public static Token DashMatch() => new(TokenKind.DashMatch);
 
         /// <summary>
         /// Creates a prefix-match token.
         /// </summary>
-        public static Token PrefixMatch() => new Token(TokenKind.PrefixMatch);
+        public static Token PrefixMatch() => new(TokenKind.PrefixMatch);
 
         /// <summary>
         /// Creates a suffix-match token.
         /// </summary>
-        public static Token SuffixMatch() => new Token(TokenKind.SuffixMatch);
+        public static Token SuffixMatch() => new(TokenKind.SuffixMatch);
 
         /// <summary>
         /// Creates a substring-match token.
         /// </summary>
-        public static Token SubstringMatch() => new Token(TokenKind.SubstringMatch);
+        public static Token SubstringMatch() => new(TokenKind.SubstringMatch);
 
         /// <summary>
         /// Creates a general sibling token.
         /// </summary>
-        public static Token Tilde() => new Token(TokenKind.Tilde);
+        public static Token Tilde() => new(TokenKind.Tilde);
 
         /// <summary>
         /// Creates an identifier token.
@@ -159,7 +158,9 @@ namespace Fizzler
         /// <summary>
         /// Creates an integer token.
         /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name (by-design)
         public static Token Integer(string text)
+#pragma warning restore CA1720 // Identifier contains type name
         {
             ValidateTextArgument(text);
             return new Token(TokenKind.Integer, text);
@@ -186,8 +187,10 @@ namespace Fizzler
         /// <summary>
         /// Creates a string token.
         /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name (by-design)
         public static Token String(string? text) =>
-            new Token(TokenKind.String, text ?? string.Empty);
+            new(TokenKind.String, text ?? string.Empty);
+#pragma warning restore CA1720 // Identifier contains type name
 
         /// <summary>
         /// Creates a function token.
@@ -201,13 +204,14 @@ namespace Fizzler
         /// <summary>
         /// Creates a not token.
         /// </summary>
-        public static Token Not() => new Token(TokenKind.Not);
+        public static Token Not() => new(TokenKind.Not);
 
         /// <summary>
         /// Creates an arbitrary character token.
         /// </summary>
-        public static Token Char(char ch) =>
-            new Token(TokenKind.Char, ch.ToString());
+#pragma warning disable CA1720 // Identifier contains type name (by-design)
+        public static Token Char(char ch) => new(TokenKind.Char, ch.ToString());
+#pragma warning restore CA1720 // Identifier contains type name
 
         /// <summary>
         /// Indicates whether this instance and a specified object are equal.

--- a/src/TokenKind.cs
+++ b/src/TokenKind.cs
@@ -19,6 +19,8 @@
 //
 #endregion
 
+#pragma warning disable CA1720 // Identifier contains type name (by-design)
+
 namespace Fizzler
 {
     /// <summary>

--- a/src/UnreachableException.cs
+++ b/src/UnreachableException.cs
@@ -1,0 +1,62 @@
+#region License and Terms
+// The MIT License (MIT)
+//
+// Copyright (c) .NET Foundation and Contributors
+//
+// All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#endregion
+
+#if NET7_0_OR_GREATER
+
+global using UnreachableException = System.Diagnostics.UnreachableException;
+
+#else
+
+namespace Fizzler
+{
+    using System;
+
+    // Source: https://github.com/dotnet/runtime/blob/v7.0.2/src/libraries/System.Private.CoreLib/src/System/Diagnostics/UnreachableException.cs
+
+    /// <summary>
+    /// Exception thrown when the program executes an instruction that was thought to be unreachable.
+    /// </summary>
+
+#if !NETSTANDARD1_0
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+#endif
+#pragma warning disable CA1064 // Exceptions should be public
+    sealed class UnreachableException : Exception
+#pragma warning restore CA1064 // Exceptions should be public
+    {
+        public UnreachableException() :
+            this(null) { }
+
+        public UnreachableException(string? message) :
+            base(message, null) { }
+
+        public UnreachableException(string? message, Exception? innerException) :
+            base(message ?? "The program executed an instruction that was thought to be unreachable.",
+                 innerException) { }
+    }
+}
+
+#endif // NET7_0_OR_GREATER

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,0 +1,9 @@
+# http://editorconfig.org/
+
+[*Tests.cs]
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = silent
+
+# CA1034: Nested types should not be visible
+dotnet_diagnostic.CA1034.severity = suggestion

--- a/tests/HumanReadableSelectorGeneratorTests.cs
+++ b/tests/HumanReadableSelectorGeneratorTests.cs
@@ -164,8 +164,7 @@ namespace Fizzler.Tests
 
         static void Run(string selector, string message)
         {
-            var generator = new HumanReadableSelectorGenerator();
-            Parser.Parse(selector, generator);
+            var generator = Parser.Parse(selector, new HumanReadableSelectorGenerator());
             Assert.That(generator.Text, Is.EqualTo(message));
         }
     }

--- a/tests/ParserTests.cs
+++ b/tests/ParserTests.cs
@@ -40,8 +40,8 @@ namespace Fizzler.Tests
         [TestCase(":not([foo][bar])")]
         public void Invalid(string selector)
         {
-            Assert.Throws<FormatException>(() =>
-                Parser.Parse(Tokener.Tokenize(selector), new NoSelectorGenerator()));
+            Assert.That(() => Parser.Parse(Tokener.Tokenize(selector), new NoSelectorGenerator()),
+                        Throws.TypeOf<FormatException>());
         }
 
         [Test]
@@ -318,9 +318,7 @@ namespace Fizzler.Tests
 
         static void Test<T1>(string input, Func<TestSelectorGenerator, T1> actual1, T1 expected1)
         {
-            Test(input,
-                new Func<TestSelectorGenerator, object?>[] { g => actual1(g) },
-                new object?[] { expected1 });
+            Test(input, [g => actual1(g)], [expected1]);
         }
 
         static void Test<T1, T2>(string input,
@@ -328,8 +326,8 @@ namespace Fizzler.Tests
             Func<TestSelectorGenerator, T2> actual2, T2 expected2)
         {
             Test(input,
-                new Func<TestSelectorGenerator, object?>[] {g => actual1(g), g => actual2(g)},
-                new object?[] {expected1, expected2});
+                 [g => actual1(g), g => actual2(g)],
+                 [expected1, expected2]);
         }
 
         static void Test<T1, T2, T3>(string input,
@@ -338,55 +336,52 @@ namespace Fizzler.Tests
             Func<TestSelectorGenerator, T3> actual3, T2 expected3)
         {
             Test(input,
-                new Func<TestSelectorGenerator, object?>[] { g => actual1(g), g => actual2(g), g => actual3(g) },
-                new object?[] { expected1, expected2, expected3 });
+                 [g => actual1(g), g => actual2(g), g => actual3(g)],
+                 [expected1, expected2, expected3]);
         }
 
         static void Test(string input,
             IEnumerable<Func<TestSelectorGenerator, object?>> actuals,
             IEnumerable<object?> expectations)
         {
-            var generator = new TestSelectorGenerator();
-            Parser.Parse(Tokener.Tokenize(input), generator);
-            using (var actual = actuals.GetEnumerator())
-            using (var expected = expectations.GetEnumerator())
+            var generator = Parser.Parse(Tokener.Tokenize(input), new TestSelectorGenerator());
+            using var actual = actuals.GetEnumerator();
+            using var expected = expectations.GetEnumerator();
+            while(actual.MoveNext())
             {
-                while(actual.MoveNext())
-                {
-                    Assert.That(expected.MoveNext(), Is.True, "Missing expectation");
-                    Assert.That(actual.Current(generator), Is.EqualTo(expected.Current));
-                }
-                Assert.That(expected.MoveNext(), Is.False, "Too many expectations");
+                Assert.That(expected.MoveNext(), Is.True, "Missing expectation");
+                Assert.That(actual.Current(generator), Is.EqualTo(expected.Current));
             }
+            Assert.That(expected.MoveNext(), Is.False, "Too many expectations");
         }
 
         public class TestSelectorGenerator : ISelectorGenerator
         {
-            public NamespacePrefix TypePrefix;
-            public string? TypeName;
+            public NamespacePrefix TypePrefix { get; private set; }
+            public string? TypeName { get; private set; }
 
-            public NamespacePrefix UniversalPrefix;
+            public NamespacePrefix UniversalPrefix { get; private set; }
 
-            public NamespacePrefix AttributeExistsPrefix;
-            public string? AttributeExistsName;
-            public NamespacePrefix AttributeExactPrefix;
-            public string? AttributeExactName;
-            public string? AttributeExactValue;
-            public NamespacePrefix AttributeIncludesPrefix;
-            public string? AttributeIncludesName;
-            public string? AttributeIncludesValue;
-            public NamespacePrefix AttributeDashMatchPrefix;
-            public string? AttributeDashMatchName;
-            public string? AttributeDashMatchValue;
-            public NamespacePrefix AttributePrefixMatchPrefix;
-            public string? AttributePrefixMatchName;
-            public string? AttributePrefixMatchValue;
-            public NamespacePrefix AttributeSuffixMatchPrefix;
-            public string? AttributeSuffixMatchName;
-            public string? AttributeSuffixMatchValue;
-            public NamespacePrefix AttributeSubstringPrefix;
-            public string? AttributeSubstringName;
-            public string? AttributeSubstringValue;
+            public NamespacePrefix AttributeExistsPrefix { get; private set; }
+            public string? AttributeExistsName { get; private set; }
+            public NamespacePrefix AttributeExactPrefix { get; private set; }
+            public string? AttributeExactName { get; private set; }
+            public string? AttributeExactValue { get; private set; }
+            public NamespacePrefix AttributeIncludesPrefix { get; private set; }
+            public string? AttributeIncludesName { get; private set; }
+            public string? AttributeIncludesValue { get; private set; }
+            public NamespacePrefix AttributeDashMatchPrefix { get; private set; }
+            public string? AttributeDashMatchName { get; private set; }
+            public string? AttributeDashMatchValue { get; private set; }
+            public NamespacePrefix AttributePrefixMatchPrefix { get; private set; }
+            public string? AttributePrefixMatchName { get; private set; }
+            public string? AttributePrefixMatchValue { get; private set; }
+            public NamespacePrefix AttributeSuffixMatchPrefix { get; private set; }
+            public string? AttributeSuffixMatchName { get; private set; }
+            public string? AttributeSuffixMatchValue { get; private set; }
+            public NamespacePrefix AttributeSubstringPrefix { get; private set; }
+            public string? AttributeSubstringName { get; private set; }
+            public string? AttributeSubstringValue { get; private set; }
 
             public void Type(NamespacePrefix prefix, string name)
             {

--- a/tests/ReaderTests.cs
+++ b/tests/ReaderTests.cs
@@ -50,26 +50,28 @@ namespace Fizzler.Tests
         [Test]
         public void HasMoreWhenEmpty()
         {
-            Assert.That(new Reader<int>(new int[0]).HasMore, Is.False);
+            using var reader = new Reader<int>([]);
+            Assert.That(reader.HasMore, Is.False);
         }
 
         [Test]
         public void HasMoreWhenNotEmpty()
         {
-            Assert.That(new Reader<int>(new int[1]).HasMore, Is.True);
+            using var reader = new Reader<int>(new int[1]);
+            Assert.That(reader.HasMore, Is.True);
         }
 
         [Test]
         public void ReadEmpty()
         {
-            Assert.Throws<InvalidOperationException>(() =>
-                new Reader<int>(new int[0]).Read());
+            using var reader = new Reader<int>([]);
+            Assert.That(reader.Read, Throws.InvalidOperationException);
         }
 
         [Test]
         public void Unreading()
         {
-            var reader = new Reader<int>(new[] { 78, 910 });
+            using var reader = new Reader<int>([78, 910]);
             reader.Unread(56);
             reader.Unread(34);
             reader.Unread(12);
@@ -83,14 +85,14 @@ namespace Fizzler.Tests
         [Test]
         public void PeekEmpty()
         {
-            Assert.Throws<InvalidOperationException>(() =>
-                new Reader<int>(new int[0]).Peek());
+            using var reader = new Reader<int>([]);
+            Assert.That(reader.Peek, Throws.InvalidOperationException);
         }
 
         [Test]
         public void PeekNonEmpty()
         {
-            var reader = new Reader<int>(new[] { 12, 34, 56 });
+            using var reader = new Reader<int>([12, 34, 56]);
             Assert.That(reader.Peek(), Is.EqualTo(12));
             Assert.That(reader.Read(), Is.EqualTo(12));
             Assert.That(reader.Peek(), Is.EqualTo(34));
@@ -102,7 +104,8 @@ namespace Fizzler.Tests
         [Test]
         public void Enumeration()
         {
-            var e = new Reader<int>(new[] { 12, 34, 56 }).GetEnumerator();
+            using var reader = new Reader<int>([12, 34, 56]);
+            using var e = reader.GetEnumerator();
             Assert.That(e.MoveNext(), Is.True);
             Assert.That(e.Current, Is.EqualTo(12));
             Assert.That(e.MoveNext(), Is.True);
@@ -115,7 +118,8 @@ namespace Fizzler.Tests
         [Test]
         public void EnumerationNonGeneric()
         {
-            var e = ((IEnumerable) new Reader<int>(new[] { 12, 34, 56 })).GetEnumerator();
+            using var reader = new Reader<int>([12, 34, 56]);
+            var e = ((IEnumerable) reader).GetEnumerator();
             Assert.That(e.MoveNext(), Is.True);
             Assert.That(e.Current, Is.EqualTo(12));
             Assert.That(e.MoveNext(), Is.True);
@@ -128,7 +132,7 @@ namespace Fizzler.Tests
         [Test]
         public void CloseDisposes()
         {
-            var e = new TestEnumerator<object>();
+            using var e = new TestEnumerator<object>();
             Assert.That(e.Disposed, Is.False);
             new Reader<object>(e).Close();
             Assert.That(e.Disposed, Is.True);
@@ -137,7 +141,7 @@ namespace Fizzler.Tests
         [Test]
         public void DisposeDisposes()
         {
-            var e = new TestEnumerator<object>();
+            using var e = new TestEnumerator<object>();
             Assert.That(e.Disposed, Is.False);
             ((IDisposable) new Reader<object>(e)).Dispose();
             Assert.That(e.Disposed, Is.True);
@@ -146,9 +150,9 @@ namespace Fizzler.Tests
         [Test]
         public void DisposeDisposesOnce()
         {
-            var e = new TestEnumerator<object>();
+            using var e = new TestEnumerator<object>();
             Assert.That(e.Disposed, Is.False);
-            var disposable = ((IDisposable)new Reader<object>(e));
+            IDisposable disposable = new Reader<object>(e);
             disposable.Dispose();
             Assert.That(e.DisposeCallCount, Is.EqualTo(1));
             disposable.Dispose();
@@ -192,7 +196,7 @@ namespace Fizzler.Tests
 
         static Reader<T> CreateDisposedReader<T>()
         {
-            var reader = new Reader<T>(new T[0]);
+            var reader = new Reader<T>([]);
             reader.Close();
             return reader;
         }

--- a/tests/SelectorGeneratorTeeTests.cs
+++ b/tests/SelectorGeneratorTeeTests.cs
@@ -39,17 +39,17 @@ namespace Fizzler.Tests
     public class SelectorGeneratorTeeTests
     {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable. (Assigned during setup)
-        SelectorGeneratorTee _tee;
-        FakeSelectorGenerator _primary;
-        FakeSelectorGenerator _secondary;
+        SelectorGeneratorTee tee;
+        FakeSelectorGenerator primary;
+        FakeSelectorGenerator secondary;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [SetUp]
         public void Setup()
         {
-            _primary = new FakeSelectorGenerator();
-            _secondary = new FakeSelectorGenerator();
-            _tee = new SelectorGeneratorTee(_primary, _secondary);
+            this.primary = new FakeSelectorGenerator();
+            this.secondary = new FakeSelectorGenerator();
+            this.tee = new SelectorGeneratorTee(this.primary, this.secondary);
         }
 
         [Test]
@@ -69,139 +69,139 @@ namespace Fizzler.Tests
         [Test]
         public void OnInitTest()
         {
-            Run(_tee.OnInit);
+            Run(this.tee.OnInit);
         }
 
         [Test]
         public void OnCloseTest()
         {
-            Run(_tee.OnClose);
+            Run(this.tee.OnClose);
         }
 
         [Test]
         public void OnSelectorTest()
         {
-            Run(_tee.OnSelector);
+            Run(this.tee.OnSelector);
         }
 
         [Test]
         public void TypeTest()
         {
-            Run(_tee.Type, NamespacePrefix.None, "go");
+            Run(this.tee.Type, NamespacePrefix.None, "go");
         }
 
         [Test]
         public void UniversalTest()
         {
-            Run(_tee.Universal, NamespacePrefix.None);
+            Run(this.tee.Universal, NamespacePrefix.None);
         }
 
         [Test]
         public void IdTest()
         {
-            Run(_tee.Id, "hello");
+            Run(this.tee.Id, "hello");
         }
 
         [Test]
         public void ClassTest()
         {
-            Run(_tee.Class, "hello");
+            Run(this.tee.Class, "hello");
         }
 
         [Test]
         public void AttrExistsTest()
         {
-            Run(_tee.AttributeExists, NamespacePrefix.None, "hello");
+            Run(this.tee.AttributeExists, NamespacePrefix.None, "hello");
         }
 
         [Test]
         public void AttExactTest()
         {
-            Run(_tee.AttributeExact, NamespacePrefix.None, "hello", "there");
+            Run(this.tee.AttributeExact, NamespacePrefix.None, "hello", "there");
         }
 
         [Test]
         public void AttrIncludesTest()
         {
-            Run(_tee.AttributeIncludes, NamespacePrefix.None, "hello", "there");
+            Run(this.tee.AttributeIncludes, NamespacePrefix.None, "hello", "there");
         }
 
         [Test]
         public void AttrDashMatchTest()
         {
-            Run(_tee.AttributeDashMatch, NamespacePrefix.None, "hello", "there");
+            Run(this.tee.AttributeDashMatch, NamespacePrefix.None, "hello", "there");
         }
 
         [Test]
         public void AttrPrefixMatchTest()
         {
-            Run(_tee.AttributePrefixMatch,NamespacePrefix.None, "hello", "there");
+            Run(this.tee.AttributePrefixMatch,NamespacePrefix.None, "hello", "there");
         }
 
         [Test]
         public void AttrSuffixMatchTest()
         {
-            Run(_tee.AttributeSuffixMatch, NamespacePrefix.None, "hello", "there");
+            Run(this.tee.AttributeSuffixMatch, NamespacePrefix.None, "hello", "there");
         }
 
         [Test]
         public void AttrSubstringTest()
         {
-            Run(_tee.AttributeSubstring, NamespacePrefix.None, "hello", "there");
+            Run(this.tee.AttributeSubstring, NamespacePrefix.None, "hello", "there");
         }
 
         [Test]
         public void FirstChildTest()
         {
-            Run(_tee.FirstChild);
+            Run(this.tee.FirstChild);
         }
 
         [Test]
         public void LastChildTest()
         {
-            Run(_tee.LastChild);
+            Run(this.tee.LastChild);
         }
 
         [Test]
         public void NthChildTest()
         {
-            Run(_tee.NthChild, 1, 2);
+            Run(this.tee.NthChild, 1, 2);
         }
 
         [Test]
         public void OnlyChildTest()
         {
-            Run(_tee.OnlyChild);
+            Run(this.tee.OnlyChild);
         }
 
         [Test]
         public void EmptyTest()
         {
-            Run(_tee.Empty);
+            Run(this.tee.Empty);
         }
 
         [Test]
         public void ChildTest()
         {
-            Run(_tee.Child);
+            Run(this.tee.Child);
         }
 
         [Test]
         public void DescendantTest()
         {
-            Run(_tee.Descendant);
+            Run(this.tee.Descendant);
         }
 
         [Test]
         public void AdjacentTest()
         {
-            Run(_tee.Adjacent);
+            Run(this.tee.Adjacent);
         }
 
         [Test]
         public void GeneralSiblingTest()
         {
-            Run(_tee.GeneralSibling);
+            Run(this.tee.GeneralSibling);
         }
 
         void Run(Action action)
@@ -231,51 +231,46 @@ namespace Fizzler.Tests
         void RunImpl(MethodBase action, params object?[] args)
         {
             var recordings = new Queue<CallRecording<ISelectorGenerator>>(2);
-            _primary.Recorder = recordings.Enqueue;
-            _secondary.Recorder = recordings.Enqueue;
+            this.primary.Recorder = recordings.Enqueue;
+            this.secondary.Recorder = recordings.Enqueue;
 
-            action.Invoke(_tee, args);
+            _ = action.Invoke(this.tee, args);
 
             // Assert the fact that the primary and secondary methods were
             // both called with the same arguments and in the right order!
 
             var recording = recordings.Dequeue();
-            Assert.That(recording.Target, Is.SameAs(_primary));
+            Assert.That(recording.Target, Is.SameAs(this.primary));
             Assert.That(MapMethod<ISelectorGenerator>(recording.Method).Name, Is.EqualTo(action.Name));
             Assert.That(recording.Arguments, Is.EqualTo(args));
 
             recording = recordings.Dequeue();
-            Assert.That(recording.Target, Is.SameAs(_secondary));
+            Assert.That(recording.Target, Is.SameAs(this.secondary));
             Assert.That(MapMethod<ISelectorGenerator>(recording.Method).Name, Is.EqualTo(action.Name));
             Assert.That(recording.Arguments, Is.EqualTo(args));
         }
 
         static MethodInfo MapMethod<T>(MethodInfo method) where T : class
         {
+#pragma warning disable CA2201 // Do not raise reserved exception types (test code)
             var type = method.ReflectedType ?? throw new NullReferenceException();
+#pragma warning restore CA2201 // Do not raise reserved exception types
             var mapping = type.GetInterfaceMap(typeof(T));
             return mapping.InterfaceMethods
                           .Select((m, i) => new { Source = m, Target = mapping.TargetMethods[i] })
                           .Single(m => m.Target == method).Source;
         }
 
-        sealed class CallRecording<T>
+        sealed class CallRecording<T>(T target, MethodInfo method, object[] arguments)
         {
-            public T Target { get; }
-            public MethodInfo Method { get; }
-            public object[] Arguments { get; }
-
-            public CallRecording(T target, MethodInfo method, object[] arguments)
-            {
-                Target = target;
-                Method = method;
-                Arguments = arguments;
-            }
+            public T Target { get; } = target;
+            public MethodInfo Method { get; } = method;
+            public object[] Arguments { get; } = arguments;
         }
 
         sealed class FakeSelectorGenerator : ISelectorGenerator
         {
-            public Action<CallRecording<ISelectorGenerator>>? Recorder;
+            public Action<CallRecording<ISelectorGenerator>>? Recorder { get; set; }
 
             public void OnInit() =>
                 OnInvoked(MethodBase.GetCurrentMethod());

--- a/tests/Throws.cs
+++ b/tests/Throws.cs
@@ -27,6 +27,8 @@ namespace Fizzler.Tests
 
     static class Throws
     {
+        public static ExactTypeConstraint InvalidOperationException => NUnit.Framework.Throws.InvalidOperationException;
+
         public static EqualConstraint ObjectDisposedException(string objectName) =>
             ObjectDisposedException()
                .And.Property(nameof(System.ObjectDisposedException.ObjectName))

--- a/tests/TokenTests.cs
+++ b/tests/TokenTests.cs
@@ -154,7 +154,9 @@ namespace Fizzler.Tests
         }
 
         [Test]
+#pragma warning disable CA1720 // Identifier contains type name (matches subject)
         public void String()
+#pragma warning restore CA1720 // Identifier contains type name
         {
             AssertToken(TokenKind.String, "foo", Token.String("foo"));
         }
@@ -162,7 +164,7 @@ namespace Fizzler.Tests
         [Test]
         public void StringNullText()
         {
-            Token.String(null);
+            _ = Token.String(null);
         }
 
         [Test]
@@ -214,7 +216,9 @@ namespace Fizzler.Tests
         }
 
         [Test]
+#pragma warning disable CA1720 // Identifier contains type name (matches subject)
         public void Integer()
+#pragma warning restore CA1720 // Identifier contains type name
         {
             AssertToken(TokenKind.Integer, "123", Token.Integer("123"));
         }

--- a/tests/TokenerTests.cs
+++ b/tests/TokenerTests.cs
@@ -157,8 +157,8 @@ namespace Fizzler.Tests
         [Test]
         public void IdentifierUsingVendorExtensionSyntaxCannotBeginWithDigit()
         {
-            Assert.Throws<FormatException>(() =>
-                Tokener.Tokenize("-42").ToArray());
+            Assert.That(() => Tokener.Tokenize("-42").ToArray(),
+                        Throws.TypeOf<FormatException>());
         }
 
         [Test]
@@ -249,8 +249,7 @@ namespace Fizzler.Tests
         [Test]
         public void BadHash()
         {
-            Assert.Throws<FormatException>(() =>
-                Tokener.Tokenize("#").ToArray());
+            Assert.That(() => Tokener.Tokenize("#").ToArray(), Throws.TypeOf<FormatException>());
         }
 
         [Test]
@@ -281,7 +280,9 @@ namespace Fizzler.Tests
         }
 
         [Test]
+#pragma warning disable CA1720 // Identifier contains type name (matches subject)
         public void Integer()
+#pragma warning restore CA1720 // Identifier contains type name
         {
             Assert.That(Tokener.Tokenize("42").First(), Is.EqualTo(Token.Integer("42")));
         }
@@ -331,23 +332,20 @@ namespace Fizzler.Tests
         [Test]
         public void StringSingleQuoteUnterminated()
         {
-            Assert.Throws<FormatException>(() =>
-                Tokener.Tokenize("'foo").ToArray());
+            Assert.That(() => Tokener.Tokenize("'foo").ToArray(), Throws.TypeOf<FormatException>());
         }
 
         [Test]
         public void StringDoubleQuoteUnterminated()
         {
-            Assert.Throws<FormatException>(() =>
-                Tokener.Tokenize("\"foo").ToArray());
+            Assert.That(() => Tokener.Tokenize("\"foo").ToArray(), Throws.TypeOf<FormatException>());
         }
 
         [TestCase(@"'f\oo")]
         [TestCase(@"'foo\")]
         public void StringInvalidEscaping(string input)
         {
-            Assert.Throws<FormatException>(() =>
-                Tokener.Tokenize(input).ToArray());
+            Assert.That(() => Tokener.Tokenize(input).ToArray(), Throws.TypeOf<FormatException>());
         }
 
         [Test]
@@ -368,8 +366,7 @@ namespace Fizzler.Tests
         [Test]
         public void InvalidChar()
         {
-            Assert.Throws<FormatException>(() =>
-                Tokener.Tokenize("what?").ToArray());
+            Assert.That(() => Tokener.Tokenize("what?").ToArray(), Throws.TypeOf<FormatException>());
         }
 
         [Test]


### PR DESCRIPTION
This PR enables, enforces and addresses styles and static code analysis warnings/errors.

Summary of flagged and addressed issues:

- [CA1051]: Do not declare visible instance fields 
- [CA1063]: Ensure that '&hellip;' is declared as public and sealed; Rename '&hellip;' to '&hellip;' and ensure that it is declared as public and sealed 
- [CA1066]: Type &hellip; should implement IEquatable<T> because it overrides Equals 
- [CA1305]: The behavior of '&hellip;' could vary based on the current user's locale settings.
- [CA1716]: Rename virtual/interface member &hellip; so that it no longer conflicts with the reserved language keyword '&hellip;'.
- [CA1720]: Identifier '&hellip;' contains type name 
- [CA1725]: In member &hellip;, change parameter name type to name in order to match the identifier as it has been declared in &hellip;
- [CA1815]: &hellip; should override the equality (==) and inequality (!=) operators 
- [CA1825]: Avoid unnecessary zero-length array allocations.
- [CA1859]: Change type of parameter '&hellip;' from '&hellip;' to '&hellip;' for improved performance 
- [CA1861]: Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array 
- [CA2000]: Call System.IDisposable.Dispose on object created by '&hellip;' before all references to it are out of scope 
- [CA2201]: Exception &hellip; is not sufficiently specific; Exception type &hellip; is reserved by the runtime 
- [CA2231]: Implement the equality operators and make their behavior identical to that of the Equals method 
- [IDE0009]: Add 'this' or 'Me' qualification 
- [IDE0010]: Populate switch 
- [IDE0011]: Add braces to 'else' statement. 
- [IDE0019]: Use pattern matching 
- [IDE0047]: Parentheses can be removed 
- [IDE0058]: Expression value is never used 
- [IDE0063]: 'using' statement can be simplified 
- [IDE0078]: Use pattern matching 
- [IDE0090]: 'new' expression can be simplified 
- [IDE0250]: Struct can be made 'readonly' 
- [IDE0251]: Member can be made 'readonly' 
- [IDE0270]: Null check can be simplified 
- [IDE0290]: Use primary constructor 
- [IDE0300]: Collection initialization can be simplified 
- [IDE1006]: Naming rule violation
- [RS0017]: Symbol '&hellip;' is part of the declared API, but is either not public or could not be found 

[CA1051]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1051
[CA1063]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1063
[CA1066]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1066
[CA1305]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305
[CA1716]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1716
[CA1720]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1720
[CA1725]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1725
[CA1815]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815
[CA1825]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825
[CA1859]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
[CA1859]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859
[CA1861]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861
[CA2000]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2000
[CA2201]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2201
[CA2231]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2231
[IDE0009]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0009
[IDE0010]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010
[IDE0011]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0011
[IDE0019]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0019
[IDE0047]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0047
[IDE0058]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058
[IDE0063]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0063
[IDE0078]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0078
[IDE0090]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0090
[IDE0250]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250
[IDE0251]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0251
[IDE0270]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270
[IDE0290]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0290
[IDE0300]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0300
[IDE1006]: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide1006
[RS0017]: https://github.com/dotnet/roslyn-analyzers/blob/bb32f58c9e3e85002529805fcc785023d6649125/src/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.md#rs0017-remove-deleted-types-and-members-from-the-declared-api
