### PR TITLE
Convert `Token` & `NamespacePrefix` to records structs

### DIFF
--- a/src/NamespacePrefix.cs
+++ b/src/NamespacePrefix.cs
@@ -28,7 +28,7 @@ namespace Fizzler
     /// Represent a type or attribute name.
     /// </summary>
     [Serializable]
-    public readonly struct NamespacePrefix : IEquatable<NamespacePrefix>
+    public readonly record struct NamespacePrefix
     {
         /// <summary>
         /// Represents a name from either the default or any namespace
@@ -85,22 +85,6 @@ namespace Fizzler
         public bool IsSpecific => !IsNone && !IsAny;
 
         /// <summary>
-        /// Indicates whether this instance and a specified object are equal.
-        /// </summary>
-        public override bool Equals(object? obj) =>
-            obj is NamespacePrefix prefix && Equals(prefix);
-
-        /// <summary>
-        /// Indicates whether this instance and another are equal.
-        /// </summary>
-        [Pure] public bool Equals(NamespacePrefix other) => Text == other.Text;
-
-        /// <summary>
-        /// Returns the hash code for this instance.
-        /// </summary>
-        public override int GetHashCode() => Text?.GetHashCode() ?? 0;
-
-        /// <summary>
         /// Returns a string representation of this instance.
         /// </summary>
         public override string ToString() => Text ?? "(none)";
@@ -115,19 +99,5 @@ namespace Fizzler
 
             return Text + (IsNone ? null : "|") + name;
         }
-
-        // Equality operators
-
-        /// <summary>
-        /// Indicates whether two namespace prefixes are equal.
-        /// </summary>
-        public static bool operator ==(NamespacePrefix left, NamespacePrefix right) =>
-            left.Equals(right);
-
-        /// <summary>
-        /// Indicates whether two namespace prefixes are inequal.
-        /// </summary>
-        public static bool operator !=(NamespacePrefix left, NamespacePrefix right) =>
-            !left.Equals(right);
     }
 }

--- a/src/PublicAPI.Shipped.txt
+++ b/src/PublicAPI.Shipped.txt
@@ -74,7 +74,6 @@ Fizzler.ISelectorGenerator.OnSelector() -> void
 Fizzler.ISelectorGenerator.Type(Fizzler.NamespacePrefix prefix, string! name) -> void
 Fizzler.ISelectorGenerator.Universal(Fizzler.NamespacePrefix prefix) -> void
 Fizzler.NamespacePrefix
-Fizzler.NamespacePrefix.Equals(Fizzler.NamespacePrefix other) -> bool
 Fizzler.NamespacePrefix.Format(string! name) -> string!
 Fizzler.NamespacePrefix.IsAny.get -> bool
 Fizzler.NamespacePrefix.IsEmpty.get -> bool
@@ -139,7 +138,6 @@ Fizzler.SelectorGeneratorTee.Type(Fizzler.NamespacePrefix prefix, string! type) 
 Fizzler.SelectorGeneratorTee.Universal(Fizzler.NamespacePrefix prefix) -> void
 Fizzler.SelectorsCachingCompiler
 Fizzler.Token
-Fizzler.Token.Equals(Fizzler.Token other) -> bool
 Fizzler.Token.Kind.get -> Fizzler.TokenKind
 Fizzler.Token.Text.get -> string?
 Fizzler.Token.Token() -> void
@@ -162,11 +160,7 @@ Fizzler.TokenKind.SubstringMatch = 7 -> Fizzler.TokenKind
 Fizzler.TokenKind.SuffixMatch = 6 -> Fizzler.TokenKind
 Fizzler.TokenKind.Tilde = 15 -> Fizzler.TokenKind
 Fizzler.TokenKind.WhiteSpace = 11 -> Fizzler.TokenKind
-override Fizzler.NamespacePrefix.Equals(object? obj) -> bool
-override Fizzler.NamespacePrefix.GetHashCode() -> int
 override Fizzler.NamespacePrefix.ToString() -> string!
-override Fizzler.Token.Equals(object? obj) -> bool
-override Fizzler.Token.GetHashCode() -> int
 override Fizzler.Token.ToString() -> string!
 static Fizzler.Parser.Parse<TGenerator, T>(string! selectors, TGenerator generator, System.Func<TGenerator, T>! resultor) -> T
 static Fizzler.Parser.Parse<TGenerator, T>(System.Collections.Generic.IEnumerable<Fizzler.Token>! tokens, TGenerator generator, System.Func<TGenerator, T>! resultor) -> T
@@ -189,8 +183,6 @@ static Fizzler.Token.Includes() -> Fizzler.Token
 static Fizzler.Token.Integer(string! text) -> Fizzler.Token
 static Fizzler.Token.LeftBracket() -> Fizzler.Token
 static Fizzler.Token.Not() -> Fizzler.Token
-static Fizzler.Token.operator !=(Fizzler.Token a, Fizzler.Token b) -> bool
-static Fizzler.Token.operator ==(Fizzler.Token a, Fizzler.Token b) -> bool
 static Fizzler.Token.Pipe() -> Fizzler.Token
 static Fizzler.Token.Plus() -> Fizzler.Token
 static Fizzler.Token.PrefixMatch() -> Fizzler.Token

--- a/src/PublicAPI.Unshipped.txt
+++ b/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,2 @@
 #nullable enable
 Fizzler.HumanReadableSelectorGenerator.Class(string! clazz) -> void
-static Fizzler.NamespacePrefix.operator !=(Fizzler.NamespacePrefix left, Fizzler.NamespacePrefix right) -> bool
-static Fizzler.NamespacePrefix.operator ==(Fizzler.NamespacePrefix left, Fizzler.NamespacePrefix right) -> bool

--- a/src/Token.cs
+++ b/src/Token.cs
@@ -26,7 +26,7 @@ namespace Fizzler
     /// <summary>
     /// Represent a token and optionally any text associated with it.
     /// </summary>
-    public readonly struct Token : IEquatable<Token>
+    public readonly record struct Token
     {
         /// <summary>
         /// Gets the kind/type/class of the token.
@@ -214,40 +214,10 @@ namespace Fizzler
 #pragma warning restore CA1720 // Identifier contains type name
 
         /// <summary>
-        /// Indicates whether this instance and a specified object are equal.
-        /// </summary>
-        public override bool Equals(object? obj) =>
-            obj is Token token && Equals(token);
-
-        /// <summary>
-        /// Returns the hash code for this instance.
-        /// </summary>
-        public override int GetHashCode() =>
-            Text is { } text ? Kind.GetHashCode() ^ text.GetHashCode() : Kind.GetHashCode();
-
-        /// <summary>
-        /// Indicates whether the current object is equal to another object of the same type.
-        /// </summary>
-        public bool Equals(Token other) =>
-            Kind == other.Kind && Text == other.Text;
-
-        /// <summary>
         /// Gets a string representation of the token.
         /// </summary>
         public override string ToString() =>
             Text is { } text ? Kind + ": " + text : Kind.ToString();
-
-        /// <summary>
-        /// Performs a logical comparison of the two tokens to determine
-        /// whether they are equal.
-        /// </summary>
-        public static bool operator==(Token a, Token b) => a.Equals(b);
-
-        /// <summary>
-        /// Performs a logical comparison of the two tokens to determine
-        /// whether they are inequal.
-        /// </summary>
-        public static bool operator !=(Token a, Token b) => !a.Equals(b);
 
         static void ValidateTextArgument(string text)
         {


### PR DESCRIPTION
This PR converts `Token` & `NamespacePrefix` into records structs so as to have less code to maintain and let the compiler generate the same members. While members have been removed in the source and tracked API, the following method was used to verify that no method was removed from the API surface (some may have been added by the compiler though). All unit tests still pass, but these may be removed in the future to have less test code to maintain.

## Verification of Public API Impact

Cloned `master` (at revision 49d14f567b5cd7875f4805f27e4751f03953bc05 at the time this PR was opened) to a directory called `before`:

    git clone -b master --single-branch --depth 1 https://github.com/atifaziz/Fizzler.git before

Cloned the branch of this PR to a directory called `after`:

    git clone -b record-structs --single-branch --depth 1 https://github.com/atifaziz/Fizzler.git after

Built both projects:

    pushd before
    dotnet build -c Release
    popd
    pushd after
    dotnet build -c Release
    popd

Installed [`ilspycmd`](https://www.nuget.org/packages/ilspycmd/8.2.0.7535) to disassemble the compiled assemblies

    dotnet tool install -g ilspycmd --version 8.2.0.7535

Ran the following commands to disassemble the affect types in each compiled assembly, filtering for just public members via `grep` and appending the output to [`before.txt`][before.txt] and [`after.txt`][after.txt], respectively:

    ilspycmd -lv CSharp1 -t Fizzler.NamespacePrefix before\bin\Release\netstandard2.0\Fizzler.dll | grep -E "^\s+public\b" >> before.txt
    ilspycmd -lv CSharp1 -t Fizzler.Token before\bin\Release\netstandard2.0\Fizzler.dll | grep -E "^\s+public\b" >> before.txt
    ilspycmd -lv CSharp1 -t Fizzler.NamespacePrefix after\bin\Release\netstandard2.0\Fizzler.dll | grep -E "^\s+public\b" >> after.txt
    ilspycmd -lv CSharp1 -t Fizzler.Token after\bin\Release\netstandard2.0\Fizzler.dll | grep -E "^\s+public\b" >> after.txt

Finally, used `diff` to produce the differences:

    diff -u before.txt after.txt

which demonstrates that only member order changed and nothing else was added or removed publicly:

```diff
--- .\before.txt
+++ .\after.txt
@@ -8,13 +8,13 @@
 		public bool IsEmpty
 		public bool IsSpecific
 		public NamespacePrefix(string text)
-		public override bool Equals(object obj)
-		public bool Equals(NamespacePrefix other)
-		public override int GetHashCode()
 		public override string ToString()
 		public string Format(string name)
-		public static bool operator ==(NamespacePrefix left, NamespacePrefix right)
 		public static bool operator !=(NamespacePrefix left, NamespacePrefix right)
+		public static bool operator ==(NamespacePrefix left, NamespacePrefix right)
+		public override int GetHashCode()
+		public override bool Equals(object obj)
+		public bool Equals(NamespacePrefix other)
 	public struct Token : IEquatable<Token>
 		public TokenKind Kind
 		public string Text
@@ -44,9 +44,9 @@
 		public static Token Function(string text)
 		public static Token Not()
 		public static Token Char(char ch)
-		public override bool Equals(object obj)
+		public override string ToString()
+		public static bool operator !=(Token left, Token right)
+		public static bool operator ==(Token left, Token right)
 		public override int GetHashCode()
+		public override bool Equals(object obj)
 		public bool Equals(Token other)
-		public override string ToString()
-		public static bool operator ==(Token a, Token b)
-		public static bool operator !=(Token a, Token b)
```

[after.txt]: https://github.com/user-attachments/files/16227625/after.txt
[before.txt]: https://github.com/user-attachments/files/16227626/before.txt

